### PR TITLE
fix: lo Ternary with lazy execution

### DIFF
--- a/service/relayer/feed.go
+++ b/service/relayer/feed.go
@@ -140,17 +140,14 @@ func (f *FeedRelayerImpl) Feeds(ctx context.Context, network constant.Network, a
 		gasUsed, err := strconv.ParseUint(tx.GasUsed, 10, 64)
 		if err != nil {
 			log.Error("failed to parse gas used", zap.Error(err))
-			continue
 		}
 
 		gasPrice, err := strconv.ParseUint(tx.GasPrice, 10, 64)
 		if err != nil {
 			log.Error("failed to parse gas price", zap.Error(err))
-			continue
 		}
-
-		methodId := lo.Ternary[string](len(tx.Input) > 10, tx.Input[:10], "0x")
-
+		// https://github.com/samber/lo/issues/174
+		methodId := lo.If(len(tx.Input) < 10, "0x").ElseF(func() string { return tx.Input[:10] })
 		txHash := strings.ToLower(tx.TransactionHash)
 		tokenLoss := make([]model.ERC20TransferWithMetadata, 0)
 		tokenGain := make([]model.ERC20TransferWithMetadata, 0)


### PR DESCRIPTION
跑测试的时候发现，当`tx.input='0x'`时，下面函数会出现slice out of bound
`lo.Ternary[string](len(tx.Input) > 10, tx.Input[:10], "0x")`
原因[参考](https://github.com/samber/lo/issues/174)